### PR TITLE
Use masala

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ authors = ["Ian S. Pringle"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+masala = "0.2"

--- a/src/birds/bluebird.rs
+++ b/src/birds/bluebird.rs
@@ -1,0 +1,27 @@
+type BluebirdT0<T> = impl Fn(T) -> T;
+/// bluebird :: b -> c -> a -> b -> a-> c
+/// The Bluebird Combinator, also known as the B combinator or function
+/// composition. This is a little harder to understand, but, essentially,
+/// it takes two functions and a value. Then applies the two functions to that
+/// value. A B combinator is the same as `b(c(a))`.
+/// ```
+/// use ornithology::birds::bluebird;
+/// let b = |x| x * 2;
+/// let c = |x| x - 1;
+/// assert_eq!(bluebird(b)(c)(3), b(c(3)))
+/// ```
+pub fn bluebird<T>(b: fn(T) -> T) -> impl Fn(fn(T) -> T) -> BluebirdT0<T> {
+    move |c| move |a| b(c(a))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bluebird() {
+        let b = |x| x * 2;
+        let c = |x| x - 1;
+        assert_eq!(bluebird(b)(c)(3), b(c(3)));
+    }
+}

--- a/src/birds/bluebird.rs
+++ b/src/birds/bluebird.rs
@@ -1,4 +1,7 @@
-type BluebirdT0<T> = impl Fn(T) -> T;
+use masala::curry;
+
+type AFunc<T> = fn(T) -> T;
+
 /// bluebird :: b -> c -> a -> b -> a-> c
 /// The Bluebird Combinator, also known as the B combinator or function
 /// composition. This is a little harder to understand, but, essentially,
@@ -10,8 +13,9 @@ type BluebirdT0<T> = impl Fn(T) -> T;
 /// let c = |x| x - 1;
 /// assert_eq!(bluebird(b)(c)(3), b(c(3)))
 /// ```
-pub fn bluebird<T>(b: fn(T) -> T) -> impl Fn(fn(T) -> T) -> BluebirdT0<T> {
-    move |c| move |a| b(c(a))
+#[curry]
+pub fn bluebird<T>(a: AFunc<T>, b: AFunc<T>, c: T) -> T {
+    a(b(c))
 }
 
 #[cfg(test)]

--- a/src/birds/cardinal.rs
+++ b/src/birds/cardinal.rs
@@ -1,0 +1,30 @@
+#![warn(missing_docs)]
+use masala::curry;
+use std::ops::Div;
+
+/// cardinal :: a -> b -> a
+/// The Cardinal Combinator, also known as the C combinator, takes a function
+/// and two values, and then flips the two values and runs them in the function.
+/// ```
+/// use ornithology::birds::cardinal;
+/// let divide = |x, y| x / y;
+/// assert_eq!(cardinal(divide)(1)(3), divide(3, 1))
+/// ```
+#[curry]
+pub fn cardinal<T: Clone>(a: fn(T, T) -> T, b: T, c: T) -> T {
+    a(c.clone(), b.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn divide<T: Div<Output = T>>(a: T, b: T) -> T {
+        a / b
+    }
+
+    #[test]
+    fn test_cardinal() {
+        assert_eq!(cardinal(divide)(4)(5), divide(5, 4));
+    }
+}

--- a/src/birds/cardinal.rs
+++ b/src/birds/cardinal.rs
@@ -2,7 +2,7 @@
 use masala::curry;
 use std::ops::Div;
 
-/// cardinal :: a -> b -> a
+/// cardinal :: a -> b -> c -> b -> a -> c
 /// The Cardinal Combinator, also known as the C combinator, takes a function
 /// and two values, and then flips the two values and runs them in the function.
 /// ```

--- a/src/birds/kestrel.rs
+++ b/src/birds/kestrel.rs
@@ -1,4 +1,6 @@
 #![warn(missing_docs)]
+use masala::curry;
+
 /// kestrel :: a -> b -> a
 /// The Kestrel Combinator, also known as the K combinator, returns the first
 /// thing it was given.
@@ -7,8 +9,9 @@
 ///
 /// assert_eq!(kestrel("bird")("cat"), "bird")
 /// ```
-pub fn kestrel<T: Clone>(a: T) -> impl Fn(T) -> T {
-    move |_b: T| -> T { return a.clone() }
+#[curry]
+pub fn kestrel<T: Clone>(a: T, _b: T) -> T {
+    a.clone()
 }
 
 #[cfg(test)]

--- a/src/birds/mod.rs
+++ b/src/birds/mod.rs
@@ -6,3 +6,6 @@ pub use kestrel::kestrel;
 
 mod bluebird;
 pub use bluebird::bluebird;
+
+mod cardinal;
+pub use cardinal::cardinal;

--- a/src/birds/mod.rs
+++ b/src/birds/mod.rs
@@ -3,3 +3,6 @@ pub use idiot::idiot;
 
 mod kestrel;
 pub use kestrel::kestrel;
+
+mod bluebird;
+pub use bluebird::bluebird;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
+#![feature(type_alias_impl_trait)]
+#![feature(min_type_alias_impl_trait)]
 #![deny(
     missing_debug_implementations,
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
     unsafe_code,
-    unstable_features,
     unused_import_braces,
     unused_qualifications
 )]


### PR DESCRIPTION
Use the masala::curry macro to autocurry. Really takes the head-ache out of some of the combinators, especially onces that take multiple functions as parameters.

Using this does mean it will only run on nightly and only on nightly when a few features are enabled, but I had to do this anyway to get `impl Fn(_)...` stuff working so, might as well make it easier!